### PR TITLE
typing.Tuple support, LF enforce and Exception for Union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py text eol=lf

--- a/deserialize/__init__.py
+++ b/deserialize/__init__.py
@@ -47,6 +47,9 @@ def _deserialize(class_reference, data, debug_name):
     if isinstance(data, list):
         return _deserialize_list(class_reference, data, debug_name)
 
+    if isinstance(data, tuple) and is_typing_type(class_reference):
+        return _deserialize_tuple(class_reference, data, debug_name)
+
     if not is_typing_type(class_reference) and issubclass(class_reference, enum.Enum):
         try:
             return class_reference(data)
@@ -86,6 +89,26 @@ def _deserialize_list(class_reference, list_data, debug_name):
         output.append(deserialized)
 
     return output
+
+
+
+def _deserialize_tuple(class_reference, tuple_data, debug_name):
+
+    if not isinstance(tuple_data, tuple):
+        raise DeserializeException(f"Cannot deserialize '{type(tuple_data)}' as a list.")
+
+    if not is_tuple(class_reference):
+        raise DeserializeException(f"Cannot deserialize a tuple to '{class_reference}'")
+
+    tuple_content_types_value = tuple_content_types(class_reference)
+
+    output = []
+
+    for index, (item, item_type) in enumerate(zip(tuple_data, tuple_content_types_value)):
+        deserialized = _deserialize(item_type, item, f"{debug_name}[{index}]")
+        output.append(deserialized)
+
+    return tuple(output)
 
 
 def _deserialize_dict(class_reference, data, debug_name):

--- a/deserialize/__init__.py
+++ b/deserialize/__init__.py
@@ -117,6 +117,9 @@ def _deserialize_dict(class_reference, data, debug_name):
     # Check if we are doing a straightforward dictionary parse first, or if it
     # has to be deserialized
     if is_dict(class_reference):
+        if class_reference is dict:
+            # If types of dictionary entries are not defined, do not deserialize
+            return data
         key_type, value_type = dict_content_types(class_reference)
         result = {}
 

--- a/deserialize/__init__.py
+++ b/deserialize/__init__.py
@@ -37,8 +37,9 @@ def _deserialize(class_reference, data, debug_name):
         for valid_type in valid_types:
             try:
                 return _deserialize(valid_type, data, debug_name)
-            except:
+            except DeserializeException:
                 pass
+        raise DeserializeException(f"Cannot deserialize '{type(data)}' to '{class_reference}' for '{debug_name}'")
 
     if isinstance(data, dict):
         return _deserialize_dict(class_reference, data, debug_name)

--- a/deserialize/__init__.py
+++ b/deserialize/__init__.py
@@ -75,10 +75,10 @@ def _deserialize(class_reference, data, debug_name):
 def _deserialize_list(class_reference, list_data, debug_name):
 
     if not isinstance(list_data, list):
-        raise DeserializeException(f"Cannot deserialize '{type(list_data)}' as a list.")
+        raise DeserializeException(f"Cannot deserialize '{type(list_data)}' as a list for {debug_name}")
 
     if not is_list(class_reference):
-        raise DeserializeException(f"Cannot deserialize a list to '{class_reference}'")
+        raise DeserializeException(f"Cannot deserialize a list to '{class_reference}' for {debug_name}")
 
     list_content_type_value = list_content_type(class_reference)
 
@@ -95,10 +95,10 @@ def _deserialize_list(class_reference, list_data, debug_name):
 def _deserialize_tuple(class_reference, tuple_data, debug_name):
 
     if not isinstance(tuple_data, tuple):
-        raise DeserializeException(f"Cannot deserialize '{type(tuple_data)}' as a list.")
+        raise DeserializeException(f"Cannot deserialize '{type(tuple_data)}' as a list for {debug_name}")
 
     if not is_tuple(class_reference):
-        raise DeserializeException(f"Cannot deserialize a tuple to '{class_reference}'")
+        raise DeserializeException(f"Cannot deserialize a tuple to '{class_reference}' for {debug_name}")
 
     tuple_content_types_value = tuple_content_types(class_reference)
 

--- a/deserialize/type_checks.py
+++ b/deserialize/type_checks.py
@@ -61,6 +61,18 @@ def is_list(type_value):
         return False
 
 
+def list_content_type(type_value):
+    """Strip the List wrapper from a type.
+
+    e.g. List[int] -> int
+    """
+
+    if not is_list(type_value):
+        raise TypeError(f"{type_value} is not a List type")
+
+    return type_value.__args__[0]
+
+
 def is_tuple(type_value):
     """Check if a type is a tuple type."""
 
@@ -73,18 +85,6 @@ def is_tuple(type_value):
         return type_value.__origin__ == tuple
     except AttributeError:
         return False
-
-
-def list_content_type(type_value):
-    """Strip the List wrapper from a type.
-
-    e.g. List[int] -> int
-    """
-
-    if not is_list(type_value):
-        raise TypeError(f"{type_value} is not a List type")
-
-    return type_value.__args__[0]
 
 
 def tuple_content_types(type_value):

--- a/deserialize/type_checks.py
+++ b/deserialize/type_checks.py
@@ -61,6 +61,20 @@ def is_list(type_value):
         return False
 
 
+def is_tuple(type_value):
+    """Check if a type is a tuple type."""
+
+    if not is_typing_type(type_value):
+        return False
+
+    try:
+        if sys.version_info < (3, 7):
+            return type_value.__origin__ == typing.Tuple
+        return type_value.__origin__ == tuple
+    except AttributeError:
+        return False
+
+
 def list_content_type(type_value):
     """Strip the List wrapper from a type.
 
@@ -71,6 +85,18 @@ def list_content_type(type_value):
         raise TypeError(f"{type_value} is not a List type")
 
     return type_value.__args__[0]
+
+
+def tuple_content_types(type_value):
+    """Strip the Tuple wrapper from a type.
+
+    e.g. Tuple[int, str] -> [int, str]
+    """
+
+    if not is_tuple(type_value):
+        raise TypeError(f"{type_value} is not a Tuple type")
+
+    return type_value.__args__
 
 
 def is_dict(type_value):

--- a/deserialize/type_checks.py
+++ b/deserialize/type_checks.py
@@ -102,6 +102,9 @@ def tuple_content_types(type_value):
 def is_dict(type_value):
     """Check if a type is a dict type."""
 
+    if type_value is dict:
+        return True
+
     if not is_typing_type(type_value):
         return False
 

--- a/tests/test_deserialize.py
+++ b/tests/test_deserialize.py
@@ -3,7 +3,7 @@
 import os
 import re
 import sys
-from typing import Callable, Dict, List, Optional, Pattern
+from typing import Callable, Dict, List, Optional, Pattern, Union
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -83,6 +83,11 @@ class TypeWithComplexDict:
     """Test a class that has a complex dict embedded."""
     value: int
     dict_value: Dict[str, TypeWithDict]
+
+
+class TypeWithUnion:
+    """Test a class that has a Union embedded."""
+    union_value: Union[str, int]
 
 
 class NonJsonTypes:
@@ -405,6 +410,32 @@ class DeserializationTestSuite(unittest.TestCase):
         for test_case in failure_cases:
             with self.assertRaises(deserialize.DeserializeException):
                 _ = deserialize.deserialize(TypeWithComplexDict, test_case)
+
+    def test_type_with_union(self):
+        """Test parsing types with complex dicts."""
+
+        test_cases = [
+            {
+                "union_value": "one"
+            },
+            {
+                "union_value": 1
+            },
+        ]
+
+        for test_case in test_cases:
+            instance = deserialize.deserialize(TypeWithUnion, test_case)
+            self.assertEqual(instance.union_value, test_case["union_value"])
+
+        failure_cases = [
+            {
+                "union_value": None
+            },
+        ]
+
+        for test_case in failure_cases:
+            with self.assertRaises(deserialize.DeserializeException):
+                _ = deserialize.deserialize(TypeWithUnion, test_case)
 
     def test_non_json_types(self):
         """Test parsing types that are not JSON compatible."""

--- a/tests/test_deserialize.py
+++ b/tests/test_deserialize.py
@@ -56,7 +56,6 @@ class ComplexNestedType:
     five: Optional[SinglePropertySimpleType]
     six: List[SinglePropertyComplexType]
 
-
     def __str__(self):
         return str({
             "one": self.one,
@@ -66,6 +65,12 @@ class ComplexNestedType:
             "five": str(self.five),
             "six": str([str(item) for item in self.six])
         })
+
+
+class TypeWithSimpleDict:
+    """Test a class that has a simple dict embedded."""
+    value: int
+    dict_value: dict
 
 
 class TypeWithDict:
@@ -297,6 +302,40 @@ class DeserializationTestSuite(unittest.TestCase):
                     2: "two"
                 }
             },
+            {
+                "value": 1,
+                "dict_value": []
+            },
+        ]
+
+        for test_case in failure_cases:
+            with self.assertRaises(deserialize.DeserializeException):
+                _ = deserialize.deserialize(TypeWithDict, test_case)
+
+    def test_type_with_simple_dict(self):
+        """Test parsing types with dicts."""
+
+        test_cases = [
+            {
+                "value": 1,
+                "dict_value": {
+                    "Hello": 1,
+                    "World": 2
+                }
+            },
+            {
+                "value": 1,
+                "dict_value": {}
+            },
+        ]
+
+        for test_case in test_cases:
+            instance = deserialize.deserialize(TypeWithSimpleDict, test_case)
+            self.assertEqual(instance.value, test_case["value"])
+            for key, value in test_case["dict_value"].items():
+                self.assertEqual(instance.dict_value.get(key), value)
+
+        failure_cases = [
             {
                 "value": 1,
                 "dict_value": []

--- a/tests/test_type_checks.py
+++ b/tests/test_type_checks.py
@@ -117,6 +117,7 @@ class TypeCheckTestSuite(unittest.TestCase):
     def test_is_dict(self):
         """Test is_dict."""
 
+        self.assertTrue(deserialize.is_dict(dict))
         self.assertTrue(deserialize.is_dict(Dict[int, int]))
         self.assertTrue(deserialize.is_dict(Dict[str, int]))
         self.assertTrue(deserialize.is_dict(Dict[str, Dict[str, str]]))


### PR DESCRIPTION
This PR should primarily add support for `typing.Tuple`.
Additionally I added a .gitattributes file, which enforces LF ending for all Python files.
Also, I added an Exception for when there are no fitting Union types