### PR TITLE
Add support for plain python dict

### DIFF
--- a/deserialize/__init__.py
+++ b/deserialize/__init__.py
@@ -93,6 +93,9 @@ def _deserialize_dict(class_reference, data, debug_name):
     # Check if we are doing a straightforward dictionary parse first, or if it
     # has to be deserialized
     if is_dict(class_reference):
+        if class_reference is dict:
+            # If types of dictionary entries are not defined, do not deserialize
+            return data
         key_type, value_type = dict_content_types(class_reference)
         result = {}
 

--- a/deserialize/type_checks.py
+++ b/deserialize/type_checks.py
@@ -76,6 +76,9 @@ def list_content_type(type_value):
 def is_dict(type_value):
     """Check if a type is a dict type."""
 
+    if type_value is dict:
+        return True
+
     if not is_typing_type(type_value):
         return False
 

--- a/tests/test_deserialize.py
+++ b/tests/test_deserialize.py
@@ -56,7 +56,6 @@ class ComplexNestedType:
     five: Optional[SinglePropertySimpleType]
     six: List[SinglePropertyComplexType]
 
-
     def __str__(self):
         return str({
             "one": self.one,
@@ -66,6 +65,12 @@ class ComplexNestedType:
             "five": str(self.five),
             "six": str([str(item) for item in self.six])
         })
+
+
+class TypeWithSimpleDict:
+    """Test a class that has a simple dict embedded."""
+    value: int
+    dict_value: dict
 
 
 class TypeWithDict:
@@ -297,6 +302,40 @@ class DeserializationTestSuite(unittest.TestCase):
                     2: "two"
                 }
             },
+            {
+                "value": 1,
+                "dict_value": []
+            },
+        ]
+
+        for test_case in failure_cases:
+            with self.assertRaises(deserialize.DeserializeException):
+                _ = deserialize.deserialize(TypeWithDict, test_case)
+
+    def test_type_with_simple_dict(self):
+        """Test parsing types with dicts."""
+
+        test_cases = [
+            {
+                "value": 1,
+                "dict_value": {
+                    "Hello": 1,
+                    "World": 2
+                }
+            },
+            {
+                "value": 1,
+                "dict_value": {}
+            },
+        ]
+
+        for test_case in test_cases:
+            instance = deserialize.deserialize(TypeWithSimpleDict, test_case)
+            self.assertEqual(instance.value, test_case["value"])
+            for key, value in test_case["dict_value"].items():
+                self.assertEqual(instance.dict_value.get(key), value)
+
+        failure_cases = [
             {
                 "value": 1,
                 "dict_value": []

--- a/tests/test_type_checks.py
+++ b/tests/test_type_checks.py
@@ -117,6 +117,7 @@ class TypeCheckTestSuite(unittest.TestCase):
     def test_is_dict(self):
         """Test is_dict."""
 
+        self.assertTrue(deserialize.is_dict(dict))
         self.assertTrue(deserialize.is_dict(Dict[int, int]))
         self.assertTrue(deserialize.is_dict(Dict[str, int]))
         self.assertTrue(deserialize.is_dict(Dict[str, Dict[str, str]]))


### PR DESCRIPTION
Handle the case when you don't want to deserialize deeper and are happy with an arbitrary dict in you class.

```python
class TypeWithSimpleDict:
    dict_value: dict
```