### PR TITLE
Add complete context to exception for failed union deserialization

### DIFF
--- a/deserialize/__init__.py
+++ b/deserialize/__init__.py
@@ -60,7 +60,9 @@ def _deserialize(class_reference, data, debug_name, throw_on_unhandled: bool):
             except DeserializeException as exception:
                 exception.__context__ = last_exception
                 last_exception = exception
-        raise last_exception
+        raise DeserializeException(
+            f"Cannot deserialize '{type(data)}' to '{class_reference}' for '{debug_name}'"
+        ) from last_exception
 
     if isinstance(data, dict):
         return _deserialize_dict(class_reference, data, debug_name, throw_on_unhandled)

--- a/deserialize/__init__.py
+++ b/deserialize/__init__.py
@@ -53,14 +53,14 @@ def _deserialize(class_reference, data, debug_name, throw_on_unhandled: bool):
 
     if is_union(class_reference):
         valid_types = union_types(class_reference)
+        last_exception = None
         for valid_type in valid_types:
             try:
                 return _deserialize(valid_type, data, debug_name, throw_on_unhandled)
-            except DeserializeException:
-                pass
-        raise DeserializeException(
-            f"Cannot deserialize '{type(data)}' to '{class_reference}' for '{debug_name}'"
-        )
+            except DeserializeException as exception:
+                exception.__context__ = last_exception
+                last_exception = exception
+        raise last_exception
 
     if isinstance(data, dict):
         return _deserialize_dict(class_reference, data, debug_name, throw_on_unhandled)


### PR DESCRIPTION
For deep deserialization with Optional root it is really hard to debug why the deserialization fails.

E.g.
```python
from deserialize import deserialize
from typing import Optional

class SomeClass:
    deeper_dict: "Optional[DeeperClass]"
    some_int: "int"
class DeeperClass:
    id: "str"

my_dict = {"deeper_dict": {"id": 1}, "some_int": 1}
my_deserialized_dict = deserialize(SomeClass, a)
```
formerly raised
```deserialize.exceptions.DeserializeException: Cannot deserialize '<class 'dict'>' to 'typing.Union[__main__.DeeperClass, NoneType]' for 'SomeClass.deeper_dict'```

with my addition it raises
```
...
deserialize.exceptions.DeserializeException: Cannot deserialize '<class 'int'>' to '<class 'str'>' for 'SomeClass.deeper_dict.id'
During handling of the above exception, another exception occurred:
...
deserialize.exceptions.DeserializeException: Could not deserialize {'id': 1} into <class 'NoneType'> due to lack of type hints

```
where you can explicitly see that the SomeClass.deeper_dict.id is the root for the error.