### PR TITLE
Add fallback logic for by name enum deserialization.

### DIFF
--- a/deserialize/__init__.py
+++ b/deserialize/__init__.py
@@ -197,6 +197,9 @@ def _deserialize(
             return finalize(class_reference(data))
         # pylint:disable=bare-except
         except:
+            enum_by_name = getattr(class_reference, str(data), None)
+            if enum_by_name:
+                return finalize(enum_by_name)
             # pylint:enable=bare-except
             # This will be handled at the end
             pass

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -48,7 +48,6 @@ def test_enums_simple():
 
     invalid_test_cases = [
         {"my_value": 1, "my_enum": None, "my_optional_enum": 1},
-        {"my_value": 2, "my_enum": "two", "my_optional_enum": None},
         {"my_value": 3, "my_enum": 3, "my_optional_enum": "Three"},
     ]
 
@@ -70,3 +69,20 @@ def test_enums_simple():
     for test_case in invalid_test_cases:
         with pytest.raises(deserialize.DeserializeException):
             _ = deserialize.deserialize(SomeClass, test_case)
+
+
+def test_enums_deserialized_by_name():
+    """Test that items with an enum property deserializes."""
+    valid_test_cases = [
+        ({"my_value": 1, "my_enum": "one", "my_optional_enum": 1},
+         {'my_value': 1, 'my_enum': SomeStringEnum.one, 'my_optional_enum': 1})
+    ]
+
+    for test_case, expected in valid_test_cases:
+        instance = deserialize.deserialize(SomeClass, test_case)
+
+        assert expected["my_value"] == instance.my_value
+
+        assert expected['my_enum'] == instance.my_enum
+
+        assert expected["my_optional_enum"] == instance.my_optional_enum.value


### PR DESCRIPTION
When the Enum cannot be deserialized by value attempt to deserialize by the enum member name.