### PR TITLE
Fix property inheritance 

### DIFF
--- a/deserialize/decorators/base.py
+++ b/deserialize/decorators/base.py
@@ -24,7 +24,7 @@ def set_property(class_reference, property_name, key_name, property_value):
     getattr(class_reference, property_name)[class_key][key_name] = property_value
 
 
-def get_property(class_reference, property_name, key_name, sentinel_value):
+def get_property(class_reference, property_name, key_name, sentinel_value=None):
     """Get the property for the given class, property and key name."""
 
     if not hasattr(class_reference, property_name):

--- a/deserialize/decorators/base.py
+++ b/deserialize/decorators/base.py
@@ -1,0 +1,49 @@
+"""Decorators used for adding functionality to the library."""
+
+import inspect
+
+
+def _generate_key(class_reference):
+    """Generate a key for lookups."""
+    return str(class_reference)
+
+
+def set_property(class_reference, property_name, key_name, property_value):
+    """A apply a property to a class."""
+
+    if not hasattr(class_reference, property_name):
+        setattr(class_reference, property_name, {})
+
+    class_key = _generate_key(class_reference)
+
+    subclass_map = getattr(class_reference, property_name, {}).get(class_key)
+
+    if subclass_map is None:
+        getattr(class_reference, property_name)[class_key] = {}
+
+    getattr(class_reference, property_name)[class_key][key_name] = property_value
+
+
+def get_property(class_reference, property_name, key_name, sentinel_value):
+    """Get the property for the given class, property and key name."""
+
+    if not hasattr(class_reference, property_name):
+        return sentinel_value
+
+    class_key = class_key = _generate_key(class_reference)
+    subclass_map = getattr(class_reference, property_name, {}).get(class_key)
+
+    if subclass_map:
+        value = subclass_map.get(key_name, sentinel_value)
+        if value != sentinel_value:
+            return value
+
+    for superclass in inspect.getmro(class_reference):
+        if superclass == class_reference:
+            continue
+
+        value = get_property(superclass, property_name, key_name, sentinel_value)
+        if value != sentinel_value:
+            return value
+
+    return sentinel_value

--- a/deserialize/decorators/constructed.py
+++ b/deserialize/decorators/constructed.py
@@ -1,12 +1,14 @@
 """Decorators used for adding functionality to the library."""
 
+from deserialize.decorators import base
+
 
 def constructed(function):
     """A decorator function for calling when a class is constructed."""
 
     def store_constructed(class_reference):
         """Store the key map."""
-        setattr(class_reference, "__deserialize_constructed__", function)
+        base.set_property(class_reference, "__deserialize_constructed__", "constructed", function)
         return class_reference
 
     return store_constructed
@@ -15,7 +17,6 @@ def constructed(function):
 def _call_constructed(class_reference, instance):
     """Check if a property is allowed to be unhandled."""
 
-    if not hasattr(class_reference, "__deserialize_constructed__"):
-        return
-
-    class_reference.__deserialize_constructed__(instance)
+    constructor = base.get_property(class_reference, "__deserialize_constructed__", "constructed")
+    if constructor:
+        constructor(instance)

--- a/deserialize/decorators/default.py
+++ b/deserialize/decorators/default.py
@@ -1,6 +1,7 @@
 """Decorators used for adding functionality to the library."""
 
 from deserialize.exceptions import NoDefaultSpecifiedException
+from deserialize.decorators import base
 
 
 def default(key_name, default_value):
@@ -8,12 +9,7 @@ def default(key_name, default_value):
 
     def store_defaults_map(class_reference):
         """Store the defaults map."""
-
-        if not hasattr(class_reference, "__deserialize_defaults_map__"):
-            setattr(class_reference, "__deserialize_defaults_map__", {})
-
-        class_reference.__deserialize_defaults_map__[key_name] = default_value
-
+        base.set_property(class_reference, "__deserialize_defaults_map__", key_name, default_value)
         return class_reference
 
     return store_defaults_map
@@ -25,10 +21,13 @@ def _has_default(class_reference, key_name):
     :returns: True if this key has a default, False otherwise.
     """
 
-    if not hasattr(class_reference, "__deserialize_defaults_map__"):
-        return False
+    sentinel = object()
 
-    return key_name in class_reference.__deserialize_defaults_map__
+    default_value = base.get_property(
+        class_reference, "__deserialize_defaults_map__", key_name, sentinel
+    )
+
+    return default_value != sentinel
 
 
 def _get_default(class_reference, key_name):
@@ -37,10 +36,13 @@ def _get_default(class_reference, key_name):
     :raises NoDefaultSpecifiedException: If a default hasn't been specified
     """
 
-    if not hasattr(class_reference, "__deserialize_defaults_map__"):
-        raise NoDefaultSpecifiedException()
+    sentinel = object()
 
-    if key_name in class_reference.__deserialize_defaults_map__:
-        return class_reference.__deserialize_defaults_map__[key_name]
+    default_value = base.get_property(
+        class_reference, "__deserialize_defaults_map__", key_name, sentinel
+    )
+
+    if default_value != sentinel:
+        return default_value
 
     raise NoDefaultSpecifiedException()

--- a/deserialize/decorators/downcasting.py
+++ b/deserialize/decorators/downcasting.py
@@ -1,12 +1,14 @@
 """Decorators used for adding functionality to the library."""
 
+from deserialize.decorators import base
+
 
 def downcast_field(property_name):
     """A decorator function for handling downcasting."""
 
     def store_downcast_field_value(class_reference):
         """Store the key map."""
-        setattr(class_reference, "__deserialize_downcast_field__", property_name)
+        base.set_property(class_reference, "__deserialize_downcast_field__", "value", property_name)
         return class_reference
 
     return store_downcast_field_value
@@ -14,7 +16,7 @@ def downcast_field(property_name):
 
 def _get_downcast_field(class_reference):
     """Get the downcast field name if set, None otherwise."""
-    return getattr(class_reference, "__deserialize_downcast_field__", None)
+    return base.get_property(class_reference, "__deserialize_downcast_field__", "value")
 
 
 def downcast_identifier(super_class, identifier):
@@ -22,11 +24,7 @@ def downcast_identifier(super_class, identifier):
 
     def store_key_map(class_reference):
         """Store the downcast map."""
-        if not hasattr(super_class, "__deserialize_downcast_map__"):
-            setattr(super_class, "__deserialize_downcast_map__", {})
-
-        super_class.__deserialize_downcast_map__[identifier] = class_reference
-
+        base.set_property(super_class, "__deserialize_downcast_map__", identifier, class_reference)
         return class_reference
 
     return store_key_map
@@ -34,11 +32,7 @@ def downcast_identifier(super_class, identifier):
 
 def _get_downcast_class(super_class, identifier):
     """Get the downcast identifier for the given class and super class, returning None if not set"""
-
-    if not hasattr(super_class, "__deserialize_downcast_map__"):
-        return None
-
-    return super_class.__deserialize_downcast_map__.get(identifier)
+    return base.get_property(super_class, "__deserialize_downcast_map__", identifier)
 
 
 def allow_downcast_fallback():
@@ -46,7 +40,7 @@ def allow_downcast_fallback():
 
     def store(class_reference):
         """Store the allowance flag."""
-        setattr(class_reference, "__deserialize_downcast_allow_fallback__", True)
+        base.set_property(class_reference, "__deserialize_downcast_allow_fallback__", "value", True)
         return class_reference
 
     return store
@@ -54,4 +48,4 @@ def allow_downcast_fallback():
 
 def _allows_downcast_fallback(super_class):
     """Get the whether downcast can fallback to a dict or not"""
-    return getattr(super_class, "__deserialize_downcast_allow_fallback__", False)
+    return base.get_property(super_class, "__deserialize_downcast_allow_fallback__", "value", False)

--- a/deserialize/decorators/ignore.py
+++ b/deserialize/decorators/ignore.py
@@ -1,16 +1,14 @@
 """Decorators used for adding functionality to the library."""
 
+from deserialize.decorators import base
+
 
 def ignore(property_name):
     """A decorator function for marking keys as those which should be ignored."""
 
     def store_key_map(class_reference):
         """Store the key map."""
-        if not hasattr(class_reference, "__deserialize_ignore_map__"):
-            setattr(class_reference, "__deserialize_ignore_map__", {})
-
-        class_reference.__deserialize_ignore_map__[property_name] = True
-
+        base.set_property(class_reference, "__deserialize_ignore_map__", property_name, True)
         return class_reference
 
     return store_key_map
@@ -18,8 +16,4 @@ def ignore(property_name):
 
 def _should_ignore(class_reference, property_name):
     """Check if a property should be ignored."""
-
-    if not hasattr(class_reference, "__deserialize_ignore_map__"):
-        return False
-
-    return class_reference.__deserialize_ignore_map__.get(property_name, False)
+    return base.get_property(class_reference, "__deserialize_ignore_map__", property_name, False)

--- a/deserialize/decorators/key.py
+++ b/deserialize/decorators/key.py
@@ -1,16 +1,15 @@
 """Decorators used for adding functionality to the library."""
 
 
+from deserialize.decorators import base
+
+
 def key(property_name, key_name):
     """A decorator function for mapping key names to properties."""
 
     def store_key_map(class_reference):
         """Store the key map."""
-        if not hasattr(class_reference, "__deserialize_key_map__"):
-            setattr(class_reference, "__deserialize_key_map__", {})
-
-        class_reference.__deserialize_key_map__[property_name] = key_name
-
+        base.set_property(class_reference, "__deserialize_key_map__", property_name, key_name)
         return class_reference
 
     return store_key_map
@@ -19,7 +18,6 @@ def key(property_name, key_name):
 def _get_key(class_reference, property_name):
     """Get the key for the given class and property name."""
 
-    if not hasattr(class_reference, "__deserialize_key_map__"):
-        return property_name
-
-    return class_reference.__deserialize_key_map__.get(property_name, property_name)
+    return base.get_property(
+        class_reference, "__deserialize_key_map__", property_name, property_name
+    )

--- a/deserialize/decorators/parser.py
+++ b/deserialize/decorators/parser.py
@@ -1,30 +1,49 @@
 """Decorators used for adding functionality to the library."""
 
-
-def parser(key_name, parser_function):
-    """A decorator function for mapping parsers to key names."""
-
-    def store_parser_map(class_reference):
-        """Store the parser map."""
-
-        if not hasattr(class_reference, "__deserialize_parser_map__"):
-            setattr(class_reference, "__deserialize_parser_map__", {})
-
-        class_reference.__deserialize_parser_map__[key_name] = parser_function
-
-        return class_reference
-
-    return store_parser_map
+import inspect
 
 
-def _get_parser(class_reference, key_name):
-    """Get the parser for the given class and key name."""
+def _generate_key(class_reference):
+    """Generate a key for lookups."""
+    return str(class_reference)
 
-    def identity_parser(value):
-        """This parser does nothing. It's simply used as the default."""
-        return value
 
-    if not hasattr(class_reference, "__deserialize_parser_map__"):
-        return identity_parser
+def set_property(class_reference, property_name, key_name, property_value):
+    """A apply a property to a class."""
 
-    return class_reference.__deserialize_parser_map__.get(key_name, identity_parser)
+    if not hasattr(class_reference, property_name):
+        setattr(class_reference, property_name, {})
+
+    class_key = _generate_key(class_reference)
+
+    subclass_map = getattr(class_reference, property_name, {}).get(class_key)
+
+    if subclass_map is None:
+        getattr(class_reference, property_name)[class_key] = {}
+
+    getattr(class_reference, property_name)[class_key][key_name] = property_value
+
+
+def _get_property(class_reference, property_name, key_name, sentinel_value):
+    """Get the property for the given class, property and key name."""
+
+    if not hasattr(class_reference, property_name):
+        return sentinel_value
+
+    class_key = class_key = _generate_key(class_reference)
+    subclass_map = getattr(class_reference, property_name, {}).get(class_key)
+
+    if subclass_map:
+        value = subclass_map.get(key_name, sentinel_value)
+        if value != sentinel_value:
+            return value
+
+    for superclass in inspect.getmro(class_reference):
+        if superclass == class_reference:
+            continue
+
+        value = _get_property(superclass, property_name, key_name)
+        if value != sentinel_value:
+            return value
+
+    return sentinel_value

--- a/deserialize/decorators/parser.py
+++ b/deserialize/decorators/parser.py
@@ -1,49 +1,26 @@
 """Decorators used for adding functionality to the library."""
 
-import inspect
+from deserialize.decorators import base
 
 
-def _generate_key(class_reference):
-    """Generate a key for lookups."""
-    return str(class_reference)
+def _identity_parser(value):
+    """This parser does nothing. It's simply used as the default."""
+    return value
 
 
-def set_property(class_reference, property_name, key_name, property_value):
-    """A apply a property to a class."""
+def parser(key_name, parser_function):
+    """A decorator function for mapping parsers to key names."""
 
-    if not hasattr(class_reference, property_name):
-        setattr(class_reference, property_name, {})
+    def store_parser_map(class_reference):
+        """Store the parser map."""
+        base.set_property(class_reference, "__deserialize_parser_map__", key_name, parser_function)
+        return class_reference
 
-    class_key = _generate_key(class_reference)
-
-    subclass_map = getattr(class_reference, property_name, {}).get(class_key)
-
-    if subclass_map is None:
-        getattr(class_reference, property_name)[class_key] = {}
-
-    getattr(class_reference, property_name)[class_key][key_name] = property_value
+    return store_parser_map
 
 
-def _get_property(class_reference, property_name, key_name, sentinel_value):
-    """Get the property for the given class, property and key name."""
-
-    if not hasattr(class_reference, property_name):
-        return sentinel_value
-
-    class_key = class_key = _generate_key(class_reference)
-    subclass_map = getattr(class_reference, property_name, {}).get(class_key)
-
-    if subclass_map:
-        value = subclass_map.get(key_name, sentinel_value)
-        if value != sentinel_value:
-            return value
-
-    for superclass in inspect.getmro(class_reference):
-        if superclass == class_reference:
-            continue
-
-        value = _get_property(superclass, property_name, key_name)
-        if value != sentinel_value:
-            return value
-
-    return sentinel_value
+def _get_parser(class_reference, key_name):
+    """Get the parser for the given class and key name."""
+    return base.get_property(
+        class_reference, "__deserialize_parser_map__", key_name, _identity_parser
+    )

--- a/deserialize/decorators/snake.py
+++ b/deserialize/decorators/snake.py
@@ -1,17 +1,19 @@
 """Decorators used for adding functionality to the library."""
 
+from deserialize.decorators import base
+
 
 def auto_snake():
     """A decorator function for marking classes as those which should be auto-snaked."""
 
     def store(class_reference):
         """Store the allowance flag."""
-        setattr(class_reference, "__deserialize_auto_snake__", True)
+        base.set_property(class_reference, "__deserialize_auto_snake__", "value", True)
         return class_reference
 
     return store
 
 
-def _uses_auto_snake(super_class):
+def _uses_auto_snake(class_reference):
     """Get the whether auto-snake is in use or not"""
-    return getattr(super_class, "__deserialize_auto_snake__", False)
+    return base.get_property(class_reference, "__deserialize_auto_snake__", "value", False)

--- a/deserialize/decorators/unhandled.py
+++ b/deserialize/decorators/unhandled.py
@@ -1,16 +1,14 @@
 """Decorators used for adding functionality to the library."""
 
+from deserialize.decorators import base
+
 
 def allow_unhandled(key_name):
     """A decorator function for marking keys as allowed to be unhandled."""
 
     def store_allow_unhandled_map(class_reference):
         """Store the key map."""
-        if not hasattr(class_reference, "__deserialize_allow_unhandled_map__"):
-            setattr(class_reference, "__deserialize_allow_unhandled_map__", {})
-
-        class_reference.__deserialize_allow_unhandled_map__[key_name] = True
-
+        base.set_property(class_reference, "__deserialize_allow_unhandled_map__", key_name, True)
         return class_reference
 
     return store_allow_unhandled_map
@@ -19,7 +17,6 @@ def allow_unhandled(key_name):
 def _should_allow_unhandled(class_reference, key_name):
     """Check if a property is allowed to be unhandled."""
 
-    if not hasattr(class_reference, "__deserialize_allow_unhandled_map__"):
-        return False
-
-    return class_reference.__deserialize_allow_unhandled_map__.get(key_name, False)
+    return base.get_property(
+        class_reference, "__deserialize_allow_unhandled_map__", key_name, False
+    )

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -93,4 +93,3 @@ def test_enums_order():
 
         assert len(result) == len(data) == len(expected_result)
         assert result == expected_result
-

--- a/tests/test_parser_subclassing.py
+++ b/tests/test_parser_subclassing.py
@@ -1,0 +1,50 @@
+"""Test deserializing."""
+
+import decimal
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# pylint: disable=wrong-import-position
+import deserialize
+
+# pylint: enable=wrong-import-position
+
+
+def _money_amount(value: Any):
+    return decimal.Decimal(value) if value else None
+
+
+@deserialize.parser("a", _money_amount)
+class Base:
+    a: decimal.Decimal
+
+
+class Foo(Base):
+    b: str
+
+
+@deserialize.parser("b", _money_amount)
+class Bar(Base):
+    b: decimal.Decimal
+
+
+class Baz(Bar):
+    pass
+
+
+def test_deserialize_base():
+    deserialize.deserialize(Base, {"a": 1.23})
+
+
+def test_deserialize_foo():
+    deserialize.deserialize(Foo, {"a": 1.23, "b": "b"})
+
+
+def test_deserialize_bar():
+    deserialize.deserialize(Bar, {"a": 1.23, "b": 1.23})
+
+
+def test_deserialize_baz():
+    deserialize.deserialize(Bar, {"a": 1.23, "b": 1.23})


### PR DESCRIPTION
The scenario this fixes is a little difficult to explain, so here's an example (thanks to @JeremyDTaylor):

```python
import decimal
from typing import Any
import deserialize

def _money_amount(value: Any):
    return decimal.Decimal(value)

@deserialize.parser("a", _money_amount)
class Base:
    a: decimal.Decimal

class Foo(Base):
    b: str

@deserialize.parser("b", _money_amount)
class Bar(Base):
    b: decimal.Decimal
```

Setting up `Base` works as expected, setting a parser for property `a`. Should either `Foo` or `Bar` be deserialized, `a` is handled correctly. No calls into `deserialize` are made for `Foo`. When `Bar` is first loaded, a parser is attempted to be set for `b`. There isn't a `__deserialize_parser_map__` on `Bar`, but there is on `Base`. So the parser for `b` is set there. Unfortunately, when `Foo` is deserialized and we look up a parser for `b`, we find the one that `Bar` set, even though we shouldn't be using it. 

The fix is to create a mapping of each class for each property. So `__deserialize_parser_map__` used to be `Property Name -> Parser`, but is now `Class Identifier -> Property Name -> Parser`. This lets each class look for its own parsers first, and more importantly, set them, then look at each super class in turn.

Fixes #23 